### PR TITLE
fix: only run on first build

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,12 @@ export const pluginPublint = (
     }
 
     api.onAfterBuild({
-      handler: async () => {
+      handler: async ({ isFirstCompile }) => {
+        // Only run on the first compile in watch mode, or on a single build
+        if (!isFirstCompile) {
+          return;
+        }
+
         const { publint } = await import('publint');
         const { formatMessage } = await import('publint/utils');
 


### PR DESCRIPTION
Only run publint on the first build in watch mode, or on a single build.