### PR TITLE
fix: should not break the build watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Optional values:
 - `'suggestion'`: Throw on errors, warnings and suggestions.
 - `'never'`: Never throw an error.
 
+:::warning
+When running in watch mode, this plugin will print the error instead of throwing it.
+:::
+
 ## License
 
 [MIT](./LICENSE).

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ export const pluginPublint = (
     }
 
     api.onAfterBuild({
-      handler: async ({ isFirstCompile }) => {
+      handler: async ({ isFirstCompile, isWatch }) => {
         // Only run on the first compile in watch mode, or on a single build
         if (!isFirstCompile) {
           return;
@@ -144,7 +144,7 @@ export const pluginPublint = (
           }
         };
 
-        if (shouldThrow()) {
+        if (shouldThrow() && !isWatch) {
           throw new Error('Publint failed!');
         }
       },


### PR DESCRIPTION
When running in the watch build (such as `rslib build --watch`), the publint errors should not break the build.