### PR TITLE
feat!: replace picocolors with styleText and requires Node 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "repository": "https://github.com/rstackjs/rsbuild-plugin-publint",
   "license": "MIT",
   "type": "module",
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -27,7 +30,6 @@
     "pre-commit": "pnpm run lint:write"
   },
   "dependencies": {
-    "picocolors": "^1.1.1",
     "publint": "^0.3.21"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
       publint:
         specifier: ^0.3.21
         version: 0.3.21

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,22 @@
 import fs from 'node:fs/promises';
 import { join } from 'node:path';
+import { styleText } from 'node:util';
 import { type RsbuildPlugin, logger } from '@rsbuild/core';
-import color from 'picocolors';
 import type { Options } from 'publint';
+
+type MessageColor = 'red' | 'yellow' | 'cyan';
+
+const formatCountMessage = (
+  color: MessageColor,
+  count: number,
+  singular: string,
+  plural: string,
+) =>
+  [
+    styleText(color, 'Publint found '),
+    styleText([color, 'bold'], String(count)),
+    styleText(color, ` ${count === 1 ? singular : plural}:`),
+  ].join('');
 
 export type PluginPublintOptions = {
   /**
@@ -79,17 +93,13 @@ export const pluginPublint = (
           formatted.warnings.length === 0 &&
           formatted.suggestions.length === 0
         ) {
-          logger.info(color.green('Publint passed.'));
+          logger.info(styleText('green', 'Publint passed.'));
         }
 
         const errorsCount = formatted.errors.length;
         if (errorsCount > 0) {
           logger.error(
-            color.red(
-              `Publint found ${color.bold(errorsCount)} ${
-                errorsCount === 1 ? 'error' : 'errors'
-              }:`,
-            ),
+            formatCountMessage('red', errorsCount, 'error', 'errors'),
           );
           for (const message of formatted.errors) {
             if (message) {
@@ -103,11 +113,7 @@ export const pluginPublint = (
         const warningsCount = formatted.warnings.length;
         if (warningsCount > 0) {
           logger.warn(
-            color.yellow(
-              `Publint found ${color.bold(warningsCount)} ${
-                warningsCount === 1 ? 'warning' : 'warnings'
-              }:`,
-            ),
+            formatCountMessage('yellow', warningsCount, 'warning', 'warnings'),
           );
           for (const message of formatted.warnings) {
             if (message) {
@@ -121,10 +127,11 @@ export const pluginPublint = (
         const suggestionsCount = formatted.suggestions.length;
         if (suggestionsCount > 0) {
           logger.info(
-            color.cyan(
-              `Publint found ${color.bold(suggestionsCount)} ${
-                suggestionsCount === 1 ? 'suggestion' : 'suggestions'
-              }:`,
+            formatCountMessage(
+              'cyan',
+              suggestionsCount,
+              'suggestion',
+              'suggestions',
             ),
           );
           for (const message of formatted.suggestions) {


### PR DESCRIPTION
## Summary

This PR removes the direct `picocolors` dependency by switching publint log styling to Node.js `styleText`. It also declares the supported Node.js runtime range as `^20.19.0 || >=22.12.0` and refreshes the pnpm lockfile.